### PR TITLE
Legg til ekstra ekkelhet i cout-eksempelet

### DIFF
--- a/cout/cout.py
+++ b/cout/cout.py
@@ -1,9 +1,12 @@
-NEWLINE = "\n"
-
 class Cout():
     def __lshift__(self, string):
         print(string, end="")
         return self
-        
+
     def __str__(self):
         return ""
+
+global NEWLINE
+global cout
+NEWLINE = "\n"
+cout = Cout()


### PR DESCRIPTION
Når std::cout er et globalt objekt i c++, skal det søren meg være et globalt objekt i python og